### PR TITLE
optionally set configuration root path

### DIFF
--- a/sparkplug-core/src/main/resources/reference.conf
+++ b/sparkplug-core/src/main/resources/reference.conf
@@ -17,3 +17,4 @@ spark {
     spark.eventLog.dir = ${?SPARK_EVENTLOG_DIR}
   }
 }
+

--- a/sparkplug-core/src/main/scala/springnz/sparkplug/core/ConfigEnvironment.scala
+++ b/sparkplug-core/src/main/scala/springnz/sparkplug/core/ConfigEnvironment.scala
@@ -1,0 +1,22 @@
+package springnz.sparkplug.core
+
+import com.typesafe.config.ConfigFactory
+import springnz.sparkplug.util.Logging
+
+import scala.util.{ Failure, Success, Try }
+
+object ConfigEnvironment extends Logging {
+
+  val config = {
+    val rootConfig = ConfigFactory.load()
+    Try {
+      rootConfig.getString("sparkplug-config-root-path")
+    } match {
+      case Success(path) ⇒
+        log.info(s"Setting root config path [$path]")
+        rootConfig.getConfig(path)
+      case Failure(_) ⇒
+        rootConfig
+    }
+  }
+}

--- a/sparkplug-core/src/main/scala/springnz/sparkplug/core/Configurer.scala
+++ b/sparkplug-core/src/main/scala/springnz/sparkplug/core/Configurer.scala
@@ -29,7 +29,7 @@ trait MapConfigurer extends Configurer {
 class LocalConfigurer(applicationName: String, sparkMaster: Option[String] = None) extends MapConfigurer {
   import scala.collection.JavaConversions._
 
-  protected val appConfig = ConfigFactory.load()
+  protected val appConfig = ConfigEnvironment.config
 
   protected def appName = applicationName
 

--- a/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/ExecutorService.scala
+++ b/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/ExecutorService.scala
@@ -27,7 +27,7 @@ object ExecutorService extends Logging {
 
     log.info(s"Starting Sparkplug ExecutorService: SparkClient = $sparkClientPath: ${LocalDate.now()}")
 
-    val executorConfig = ConfigFactory.load().getConfig(defaultConfigSectionName)
+    val executorConfig = ConfigEnvironment.config.getConfig(defaultConfigSectionName)
     val system = ActorSystem(actorSystemName, executorConfig)
 
     val executorService = new ExecutorService(appName)

--- a/sparkplug-executor/src/test/scala/springnz/sparkplug/ExecutorServiceBrokerDeathTests.scala
+++ b/sparkplug-executor/src/test/scala/springnz/sparkplug/ExecutorServiceBrokerDeathTests.scala
@@ -2,8 +2,8 @@ package springnz.sparkplug
 
 import akka.actor._
 import akka.testkit.{ ImplicitSender, TestKit }
-import com.typesafe.config.ConfigFactory
 import org.scalatest._
+import springnz.sparkplug.core.ConfigEnvironment
 import springnz.sparkplug.executor.Constants
 import springnz.sparkplug.executor.MessageTypes._
 
@@ -15,7 +15,7 @@ class ExecutorServiceBrokerDeathTests(_system: ActorSystem)
 
   case object ServerTerminated
 
-  def this() = this(ActorSystem("TestSystemDeathWatch", ConfigFactory.load().getConfig(Constants.defaultConfigSectionName)))
+  def this() = this(ActorSystem("TestSystemDeathWatch", ConfigEnvironment.config.getConfig(Constants.defaultConfigSectionName)))
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/sparkplug-executor/src/test/scala/springnz/sparkplug/ExecutorServiceStandardTests.scala
+++ b/sparkplug-executor/src/test/scala/springnz/sparkplug/ExecutorServiceStandardTests.scala
@@ -2,8 +2,8 @@ package springnz.sparkplug
 
 import akka.actor._
 import akka.testkit.{ ImplicitSender, TestKit }
-import com.typesafe.config.ConfigFactory
 import org.scalatest._
+import springnz.sparkplug.core.ConfigEnvironment
 import springnz.sparkplug.executor.Constants
 import springnz.sparkplug.executor.MessageTypes._
 
@@ -15,7 +15,7 @@ class ExecutorServiceStandardTests(_system: ActorSystem)
 
   case object ServerTerminated
 
-  def this() = this(ActorSystem("TestSystemStandard", ConfigFactory.load().getConfig(Constants.defaultConfigSectionName)))
+  def this() = this(ActorSystem("TestSystemStandard", ConfigEnvironment.config.getConfig(Constants.defaultConfigSectionName)))
 
   override def afterAll {
     TestKit.shutdownActorSystem(system)

--- a/sparkplug-extras/src/main/scala/springnz/sparkplug/data/JdbcDataFrameExporter.scala
+++ b/sparkplug-extras/src/main/scala/springnz/sparkplug/data/JdbcDataFrameExporter.scala
@@ -2,18 +2,16 @@
 
 package springnz.sparkplug.data
 
-import com.typesafe.config.ConfigFactory
 import org.apache.spark.sql.{ DataFrame, SaveMode }
-import springnz.sparkplug.core.SparkOperation
-import springnz.sparkplug.util.{ Pimpers, Logging }
-import Pimpers._
-import springnz.sparkplug.util.Logging
+import springnz.sparkplug.core.{ ConfigEnvironment, SparkOperation }
+import springnz.sparkplug.util.{ Logging, Pimpers }
+import springnz.sparkplug.util.Pimpers._
 
 import scala.util.Try
 
 object JdbcDataFrameExporter extends Logging {
 
-  protected val config = ConfigFactory.load()
+  protected val config = ConfigEnvironment.config
 
   def export(dataBaseName: String, tableName: String, saveMode: SaveMode)(dataFrame: DataFrame): SparkOperation[(DataFrame, Try[Unit])] =
     SparkOperation { _ ⇒

--- a/sparkplug-extras/src/main/scala/springnz/sparkplug/data/JdbcDataFrameSource.scala
+++ b/sparkplug-extras/src/main/scala/springnz/sparkplug/data/JdbcDataFrameSource.scala
@@ -1,15 +1,14 @@
 package springnz.sparkplug.data
 
-import com.typesafe.config.ConfigFactory
 import org.apache.spark.sql.{ DataFrame, SQLContext }
-import springnz.sparkplug.core.SparkOperation
-import springnz.sparkplug.util.{ Pimpers, Logging }
+import springnz.sparkplug.core.{ ConfigEnvironment, SparkOperation }
+import springnz.sparkplug.util.{ Logging, Pimpers }
 
 object JdbcDataFrameSource extends Logging {
   import Pimpers._
 
   def apply(dataBaseName: String, tableName: String): SparkOperation[DataFrame] = SparkOperation { ctx ⇒
-    val config = ConfigFactory.load()
+    val config = ConfigEnvironment.config
     val connectionString = config.getString(s"spark.mysql.$dataBaseName.connectionString")
     val user = config.getString(s"spark.mysql.$dataBaseName.user")
     val password = config.getString(s"spark.mysql.$dataBaseName.password")

--- a/sparkplug-extras/src/test/scala/springnz/sparkplug/cassandra/CassandraExporterTest.scala
+++ b/sparkplug-extras/src/test/scala/springnz/sparkplug/cassandra/CassandraExporterTest.scala
@@ -3,12 +3,11 @@ package springnz.sparkplug.cassandra
 import java.time.{ LocalDate, LocalDateTime }
 
 import com.datastax.spark.connector._
-import com.typesafe.config.ConfigFactory
 import org.apache.spark.rdd.RDD
 import org.scalatest._
-import springnz.sparkplug.core.SparkOperation
+import springnz.sparkplug.core.{ ConfigEnvironment, SparkOperation }
 import springnz.sparkplug.testkit.SimpleTestContext
-import springnz.sparkplug.util.{ Logging, DateTimeUtil }
+import springnz.sparkplug.util.{ DateTimeUtil, Logging }
 
 case class TestRow(id: Int, localDate: LocalDate, localDateTime: LocalDateTime)
 
@@ -19,7 +18,7 @@ class CassandraExporterTest extends WordSpec with ShouldMatchers with Logging {
     "handle Java 8 timestamps and select rows with a given LocalDate" ignore new SimpleTestContext("CassandraExporterTest") {
       import DateTimeUtil._
 
-      val keySpace = ConfigFactory.load().getString("cassandra.test-keyspace")
+      val keySpace = ConfigEnvironment.config.getString("cassandra.test-keyspace")
       val table = "cassandra_exporter_test"
 
       val createQuery =

--- a/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/ClientExecutor.scala
+++ b/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/ClientExecutor.scala
@@ -1,10 +1,11 @@
 package springnz.sparkplug.client
 
 import akka.actor._
-import com.typesafe.config.{ Config, ConfigFactory }
+import com.typesafe.config.Config
 import com.typesafe.scalalogging.LazyLogging
+import springnz.sparkplug.core.ConfigEnvironment
 import springnz.sparkplug.executor.MessageTypes._
-import springnz.sparkplug.util.{ Pimpers, Logging }
+import springnz.sparkplug.util.Pimpers
 
 import scala.concurrent._
 import scala.concurrent.duration._
@@ -23,7 +24,7 @@ object ClientExecutor extends LazyLogging {
 
   case class ClientExecutorParams(config: Config = defaultConfig(), jarPath: Option[String] = None)
 
-  def defaultConfig() = ConfigFactory.load().getConfig(defaultConfigSectionName)
+  def defaultConfig() = ConfigEnvironment.config.getConfig(defaultConfigSectionName)
 
   def apply[A](pluginClass: String, data: Option[Any], params: ClientExecutorParams = ClientExecutorParams())(implicit ec: ExecutionContext): Future[A] = {
     val executor = create(params)

--- a/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/Coordinator.scala
+++ b/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/Coordinator.scala
@@ -2,16 +2,16 @@ package springnz.sparkplug.client
 
 import akka.actor.TypedActor.PreStart
 import akka.actor._
-import better.files._
 import better.files.File._
-import com.typesafe.config.{ Config, ConfigFactory }
+import better.files._
+import com.typesafe.config.Config
 import springnz.sparkplug.client.Constants._
-import springnz.sparkplug.client.Coordinator.JobRequestWithPromise
+import springnz.sparkplug.core.ConfigEnvironment
 import springnz.sparkplug.executor.MessageTypes._
 import springnz.sparkplug.util.Logging
 
 import scala.concurrent._
-import scala.util.{ Failure, Try, Success }
+import scala.util.{ Failure, Success, Try }
 
 object Coordinator {
   case class JobRequestWithPromise(jobRequest: JobRequest, promise: Option[Promise[Any]])
@@ -23,14 +23,14 @@ object Coordinator {
     jarPath: Option[String] = None) = Props(new Coordinator(readyPromise, config, jarPath))
 
   def defaultConfig: Config = {
-    val config = ConfigFactory.load()
+    val config = ConfigEnvironment.config
     config.getConfig(defaultConfigSectionName)
   }
 }
 
 class Coordinator(readyPromise: Option[Promise[ActorRef]], config: Config, jarPath: Option[String]) extends Actor with PreStart with Logging {
-  import Coordinator._
   import Constants._
+  import Coordinator._
 
   override def preStart() = {
     val launchTry: Try[Future[Unit]] = Try {

--- a/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/Launcher.scala
+++ b/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/Launcher.scala
@@ -3,19 +3,19 @@ package springnz.sparkplug.client
 import java.net.InetAddress
 
 import better.files._
-import com.typesafe.config.ConfigFactory
 import org.apache.spark.launcher.SparkLauncher
-import springnz.sparkplug.util.{ Pimpers, Logging, BuilderOps }
+import springnz.sparkplug.core.ConfigEnvironment
+import springnz.sparkplug.util.{ BuilderOps, Logging, Pimpers }
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 import scala.util.{ Properties, Try }
 
 object Launcher extends Logging {
-  import Pimpers._
   import BuilderOps._
+  import Pimpers._
 
-  val config = ConfigFactory.load().getConfig("sparkPlugClient.spark.conf")
+  val config = ConfigEnvironment.config.getConfig("sparkPlugClient.spark.conf")
 
   def startProcess(launcher: SparkLauncher): Future[Unit] = {
     val processFuture = Future {

--- a/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorCleanupTests.scala
+++ b/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorCleanupTests.scala
@@ -1,9 +1,9 @@
 package springnz.sparkplug.client
 
-import akka.actor.{ ActorRef, Props, ActorSystem }
-import akka.testkit.{ ImplicitSender, TestActorRef, TestKit }
-import com.typesafe.config.ConfigFactory
+import akka.actor.{ ActorRef, ActorSystem }
+import akka.testkit.{ ImplicitSender, TestKit }
 import org.scalatest._
+import springnz.sparkplug.core.ConfigEnvironment
 import springnz.sparkplug.executor.MessageTypes.{ JobRequest, JobSuccess, ShutDown }
 
 import scala.concurrent.duration._
@@ -11,7 +11,7 @@ import scala.concurrent.duration._
 class CoordinatorCleanupTests(_system: ActorSystem)
     extends TestKit(_system) with ImplicitSender with WordSpecLike with BeforeAndAfterAll with Matchers {
 
-  def this() = this(ActorSystem(Constants.actorSystemName, ConfigFactory.load().getConfig(Constants.defaultConfigSectionName)))
+  def this() = this(ActorSystem(Constants.actorSystemName, ConfigEnvironment.config.getConfig(Constants.defaultConfigSectionName)))
 
   var coordinator: ActorRef = null
 

--- a/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorTests.scala
+++ b/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorTests.scala
@@ -6,6 +6,7 @@ import akka.testkit.{ ImplicitSender, TestActorRef, TestKit }
 import akka.util.Timeout
 import com.typesafe.config.ConfigFactory
 import org.scalatest._
+import springnz.sparkplug.core.ConfigEnvironment
 import springnz.sparkplug.executor.MessageTypes.{ JobFailure, JobRequest, JobSuccess, ShutDown }
 
 import scala.concurrent.Await
@@ -14,7 +15,7 @@ import scala.concurrent.duration._
 class CoordinatorTests(_system: ActorSystem)
     extends TestKit(_system) with ImplicitSender with WordSpecLike with BeforeAndAfterAll with Matchers {
 
-  def this() = this(ActorSystem(Constants.actorSystemName, ConfigFactory.load().getConfig(Constants.defaultConfigSectionName)))
+  def this() = this(ActorSystem(Constants.actorSystemName, ConfigEnvironment.config.getConfig(Constants.defaultConfigSectionName)))
 
   var coordinator: ActorRef = null
 


### PR DESCRIPTION
Every call to `ConfigFactory.load()` has been replaced with a global `config` instance with optionally customizable root path

(IDEA automatically cleaned up / reordered some imports)
