### PR TITLE
Cancellation and Launcher Restart

### DIFF
--- a/sparkplug-core/src/main/scala/springnz/sparkplug/core/SparkOperation.scala
+++ b/sparkplug-core/src/main/scala/springnz/sparkplug/core/SparkOperation.scala
@@ -1,9 +1,7 @@
 package springnz.sparkplug.core
 
 import org.apache.spark.SparkContext
-import org.apache.spark.rdd.RDD
 
-import scala.reflect.ClassTag
 import scalaz._
 
 sealed trait SparkOperation[+A] {

--- a/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/ExecutorService.scala
+++ b/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/ExecutorService.scala
@@ -49,6 +49,7 @@ object ExecutorService extends Logging {
 
     val executorService = new ExecutorService(appName)
     executorService.start(system, sparkClientPath)
+    log.info("Terminating the remote application.")
   }
 }
 
@@ -62,6 +63,8 @@ class ExecutorService(appName: String, brokerName: String = Constants.brokerActo
     val actorOperation = SparkOperation[Unit] { implicit sparkContext ⇒
 
       def postStopAction() = {
+        log.info("Cancelling any jobs (if any are running).")
+        sparkContext.cancelAllJobs()
         log.info("Stopping Spark context.")
         sparkContext.stop()
       }

--- a/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/MessageTypes.scala
+++ b/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/MessageTypes.scala
@@ -9,6 +9,7 @@ object MessageTypes {
 
   case object ServerReady
   case object ShutDown
+  case object CancelAllJobs
 
   case class ServerError(reason: Throwable)
   case class JobRequest(factoryClassName: String, data: Option[Any] = None)
@@ -16,6 +17,7 @@ object MessageTypes {
   case class JobSuccess(jobRequest: JobRequest, response: Any)
   case class JobFailure(jobRequest: JobRequest, reason: Throwable)
 
+  class SparkplugException(message: String) extends Exception(message)
 }
 
 object InternalMessageTypes {

--- a/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/RequestBroker.scala
+++ b/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/RequestBroker.scala
@@ -80,7 +80,7 @@ class RequestBroker(sparkClient: String, postStopAction: ⇒ Unit)(implicit spar
       }
 
     case CancelAllJobs ⇒
-      log.info(s"Cancelling all Spark Jobs...")
+      log.info(s"Broker cancelling all Spark Jobs...")
       sparkContext.cancelAllJobs()
   }
 }

--- a/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/RequestBroker.scala
+++ b/sparkplug-executor/src/main/scala/springnz/sparkplug/executor/RequestBroker.scala
@@ -78,6 +78,10 @@ class RequestBroker(sparkClient: String, postStopAction: ⇒ Unit)(implicit spar
           log.error(message)
           requestor ! JobFailure(job, new SparkPlugException(message))
       }
+
+    case CancelAllJobs ⇒
+      log.info(s"Cancelling all Spark Jobs...")
+      sparkContext.cancelAllJobs()
   }
 }
 

--- a/sparkplug-launcher/src/main/resources/application.conf
+++ b/sparkplug-launcher/src/main/resources/application.conf
@@ -13,6 +13,10 @@ sparkplug {
   }
 
   akkaClient {
+    restart {
+      attempts = 3
+      delayincrements = 30
+    }
     akka {
       debug {
         # enable DEBUG logging of executor lifecycle changes

--- a/sparkplug-launcher/src/main/resources/application.conf
+++ b/sparkplug-launcher/src/main/resources/application.conf
@@ -14,8 +14,8 @@ sparkplug {
 
   akkaClient {
     restart {
-      attempts = 3
-      delayincrements = 30
+      max-attempts = 3
+      delay-increments = 30
     }
     akka {
       debug {

--- a/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/ClientExecutor.scala
+++ b/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/ClientExecutor.scala
@@ -12,6 +12,7 @@ import scala.util.Try
 
 trait ClientExecutor {
   def execute[A](pluginClass: String, data: Option[Any]): Future[A]
+  def cancelJobs(): Unit
   def shutDown(): Unit
 }
 
@@ -81,6 +82,11 @@ object ClientExecutor extends LazyLogging {
             logger.info(s"Future complete request $jobRequest. Return value: $any")
             any.asInstanceOf[A]
         }
+      }
+
+      override def cancelJobs() = {
+        coordinatorFuture.foreach(coordinator ⇒ coordinator ! CancelAllJobs)
+        Await.result(coordinatorFuture, 10.seconds)
       }
 
       override def shutDown(): Unit = {

--- a/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/Coordinator.scala
+++ b/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/Coordinator.scala
@@ -149,7 +149,9 @@ class Coordinator(
       context.actorOf(SingleJobProcessor.props(request, broker, requestor, promise, jobCounter), s"SingleJobProcessor-$jobCounter")
       context become waitForRequests(broker, jobCounter + 1, jobsOutstanding + JobRequestDetails(jobCounter, sender, request))
 
-    case ShutDown ⇒ shutDown(broker)
+    case ShutDown      ⇒ shutDown(broker)
+
+    case CancelAllJobs ⇒ cancelAllJobs(broker)
 
     case JobCompleteIndex(finishedIndex) ⇒
       log.info(s"Received forwarded completion for job: $finishedIndex")
@@ -191,5 +193,9 @@ class Coordinator(
     self ! PoisonPill
   }
 
+  def cancelAllJobs(broker: ActorRef): Unit = {
+    log.info(s"Coordinator telling broker to cancel all jobs...")
+    broker ! CancelAllJobs
+  }
 }
 

--- a/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorCleanupTests.scala
+++ b/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorCleanupTests.scala
@@ -3,7 +3,7 @@ package springnz.sparkplug.client
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ ImplicitSender, TestKit }
 import org.scalatest._
-import springnz.sparkplug.executor.MessageTypes.{CancelAllJobs, JobRequest, JobSuccess, ShutDown}
+import springnz.sparkplug.executor.MessageTypes.{ CancelAllJobs, JobRequest, JobSuccess, ShutDown }
 
 import scala.concurrent.duration._
 

--- a/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorCleanupTests.scala
+++ b/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorCleanupTests.scala
@@ -3,7 +3,7 @@ package springnz.sparkplug.client
 import akka.actor.{ ActorRef, ActorSystem }
 import akka.testkit.{ ImplicitSender, TestKit }
 import org.scalatest._
-import springnz.sparkplug.executor.MessageTypes.{ JobRequest, JobSuccess, ShutDown }
+import springnz.sparkplug.executor.MessageTypes.{CancelAllJobs, JobRequest, JobSuccess, ShutDown}
 
 import scala.concurrent.duration._
 
@@ -22,7 +22,15 @@ class CoordinatorCleanupTests(_system: ActorSystem)
       expectMsgType[JobSuccess](30.seconds)
     }
 
-    // TODO: work out a way to kill off the broker to test DeathWatch
+    "cancel all job requests" in {
+      val request = JobRequest("springnz.sparkplug.examples.WaitPlugin", None)
+      coordinator ! request
+      Thread.sleep(500)
+      coordinator ! CancelAllJobs
+      Thread.sleep(500)
+      expectMsgType[JobSuccess](30.seconds)
+    }
+
   }
 
   override def beforeAll {


### PR DESCRIPTION
This PR includes:
- Ability to handle cancellation of all jobs for a given `SparkContext` when executing remotely.
- Automatically restart launcher application and resubmit jobs in the queue (up to a certain number of times).

TODO: Need to add some test cases to test job cancellation.
