### PR TITLE
Added await termination on the actor system when shutting down client…

### DIFF
--- a/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/ClientExecutor.scala
+++ b/sparkplug-launcher/src/main/scala/springnz/sparkplug/client/ClientExecutor.scala
@@ -99,6 +99,7 @@ object ClientExecutor extends LazyLogging {
           // give it x seconds to try to shut down the Client and Server, then just terminate the actorSystem
           logger.info(s"ActorSystem '$actorSystemName' shutting down...")
           actorSystem.shutdown()
+          actorSystem.awaitTermination(params.shutdownTimeout)
         }
       }
     }

--- a/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/ClientExecutorTests.scala
+++ b/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/ClientExecutorTests.scala
@@ -20,7 +20,6 @@ trait ClientExecutableFixture extends BeforeAndAfterEach { this: Suite ⇒
     try super.afterEach()
     finally {
       executor.shutDown()
-      Thread.sleep(1000)
       // it seems to need to be give a chance to clean up (I think shutdown happens asnychronously)
     }
   }

--- a/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorTests.scala
+++ b/sparkplug-launcher/src/test/scala/springnz/sparkplug/client/CoordinatorTests.scala
@@ -52,8 +52,7 @@ class CoordinatorTests(_system: ActorSystem)
 
   override def afterAll {
     system.actorSelection(s"/user/TestCoordinator") ! ShutDown
-    TestKit.shutdownActorSystem(system)
-    Thread.sleep(1000)
+    TestKit.shutdownActorSystem(system, verifySystemShutdown = true)
   }
 
 }


### PR DESCRIPTION
… executor. This will make sure that we unbind from our remote actor port and will make the tests more consistent. Removed now unnecessary `Thread.sleep` calls in tests. Should solve "Address already in use" for port 2555 test failures
